### PR TITLE
cat: use optional output port even when first argument is a port

### DIFF
--- a/artanis/utils.scm
+++ b/artanis/utils.scm
@@ -132,14 +132,12 @@
 ;; WARN: besure that you've already checked the file exists before!!!
 (define* (cat file/port #:optional (out (current-output-port)))
   (define get-string-all (@ (rnrs io ports) get-string-all))
-  (if (port? file/port)
-      (get-string-all file/port)
-      (let ((str (if (port? file/port)
-                     (get-string-all file/port)
-                     (call-with-input-file file/port get-string-all))))
-        (if out
-            (display str out)
-            str))))
+  (let ((str (if (port? file/port)
+                 (get-string-all file/port)
+                 (call-with-input-file file/port get-string-all))))
+    (if out
+        (display str out)
+        str)))
 
 ;; WARN: besure that you've already checked the file exists before!!!
 (define* (bv-cat file/port #:optional (out (current-output-port)))


### PR DESCRIPTION
The logic was a bit weird in this function.  A branch of the second if statement was entirely occluded by the first if statement.  It seems the intended functionality is to operate as this change implements.
