### PR TITLE
tweak `make install' to make packaging easier

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -124,17 +124,19 @@ clean-config:
 	-rm -f config.{h,log}
 
 install: $(ALL_TARGETS)
-	mkdir -p $(MOD_PATH)
-	$(CP) $(MOD) $(MOD_PATH)/
-	mkdir -p $(MOD_TARGET_PATH)/
-	$(CP) $(MOD_OBJ) $(MOD_TARGET_PATH)/
-	$(CP) $(ARTANIS_ETC) /etc/
-	$(CP) $(ARTANIS_PAGES) /etc/artanis/
-	$(CP) $(BIN)/art $(PREFIX)/bin/
-	mkdir -p /etc/bash_completion.d/
-	$(CP) $(CMDCOMP) /etc/bash_completion.d/
-	source /etc/bash.bashrc
-	if [ -e artanis.info ]; then $(CP) artanis.info $(INFO_DIR)/; fi
+	mkdir -p $(DESTDIR)$(MOD_PATH)/
+	$(CP) $(MOD) $(DESTDIR)$(MOD_PATH)/
+	mkdir -p $(DESTDIR)$(MOD_TARGET_PATH)/
+	$(CP) $(MOD_OBJ) $(DESTDIR)$(MOD_TARGET_PATH)/
+	mkdir -p $(DESTDIR)/etc/
+	$(CP) $(ARTANIS_ETC) $(DESTDIR)/etc/
+	$(CP) $(ARTANIS_PAGES) $(DESTDIR)/etc/artanis/
+	mkdir -p $(DESTDIR)$(PREFIX)/bin/
+	$(CP) $(BIN)/art $(DESTDIR)$(PREFIX)/bin/
+	mkdir -p $(DESTDIR)/etc/bash_completion.d/
+	$(CP) $(CMDCOMP) $(DESTDIR)/etc/bash_completion.d/
+	mkdir -p $(DESTDIR)$(INFO_DIR)/
+	if [ -e artanis.info ]; then $(CP) artanis.info $(DESTDIR)$(INFO_DIR)/; fi
 
 distclean: distclean-mk clean clean-config clean-tarball
 	-rm -f $(BIN)/art


### PR DESCRIPTION
Hello,

I encountered #51 while trying to build an Arch package of Artanis, so here's my attempt at a fix. 

I've basically just:

1. stuffed `$(DESTDIR)` into every command in `make install`.
2. added the creation of a few system directories like `/etc` (useful for installing Artanis into an empty directory, which packaging for Arch requires)
3. removed `source /etc/bash.bashrc` because I doubt it did anything useful, considering it's running in a shell spawned by make, not the user's shell. Am I missing something here?

Let me know what you think.

Thanks!