### PR TITLE
Makefile: Fix make install if .bashrc is missing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -134,7 +134,7 @@ install: $(ALL_TARGETS)
 	$(CP) $(BIN)/art $(DESTDIR)/$(PREFIX)/bin/
 	mkdir -p $(DESTDIR)/etc/bash_completion.d/
 	$(CP) $(CMDCOMP) $(DESTDIR)/etc/bash_completion.d/
-	source /etc/bash.bashrc
+	if [ -e /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi
 	if [ -e artanis.info ]; then mkdir -p $(DESTDIR)/$(INFO_DIR); $(CP) artanis.info $(DESTDIR)/$(INFO_DIR)/; fi
 
 distclean: distclean-mk clean clean-config clean-tarball


### PR DESCRIPTION
Not every system has /etc/bash.bashrc. So conditionally
include the file.